### PR TITLE
Update mappingTable.md

### DIFF
--- a/docs/v/2025/appendix/mappingTable.md
+++ b/docs/v/2025/appendix/mappingTable.md
@@ -5,19 +5,19 @@ The following table maps the OWASP OT top 10 items to relevant standard and legi
 |OWASP OT top 10 item|Standard/Law|Requirement-ID|
 |--|--|--|
 |1. Unknown Assets and Unmanaged External Access|IEC 62443|FR 2|
-||IEC 62443-2-1:2019| CM 1|
+||IEC 62443-2-1:2019|CM 1|
 ||IEC 62443-2-1:2019|NET 3.X|
 ||IEC 62443-3-2:2020|ZCR 1|
 ||IEC 62443-3-2:2020|ZCR 3.6|
 ||IEC 62443-3-3:2020|SR 2.X|
 ||IEC 62443-3-3:2020|SR 7.8|
+||NIST SP 800-82:v3|CM-8|
+||NIST SP 800-82:v3|AC-20|
+||NIST SP 800-82:v3|AC-17|
+||NIST SP 800-82:v3|CM-2|
 ||NIST CSF 2.0|ID.AM|
 ||NIST CSF 2.0|PR.AA|
 ||NIST CSF 2.0|PR.IR-01|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.7|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|11.X|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|12.2|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|12.4|
 ||MITRE ATT&CK|M0800|
 ||MITRE ATT&CK|M0801|
 ||MITRE ATT&CK|M0804|
@@ -27,44 +27,58 @@ The following table maps the OWASP OT top 10 items to relevant standard and legi
 ||MITRE ATT&CK|M0922|
 ||MITRE ATT&CK|M0926|
 ||MITRE ATT&CK|M0932|
-||NIST SP 800-82:v3|CM-8|
-||NIST SP 800-82:v3|AC-20|
-||NIST SP 800-82:v3|AC-17|
-||NIST SP 800-82:v3|CM-2|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.7|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|11.X|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|12.2|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|12.4|
 |2. Devices with known Vulnerabilities/Issues|IEC 62443|FR3|
 ||IEC 62443|FR4|
 ||IEC 62443-3-2:2020|ZCR 5.2|
 ||IEC 62443-3-3:2020|SR 3.X|
 ||IEC 62443-3-3:2020|SR 4.X|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.5|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.6|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.10|
-||NIST CSF 2.0|ID.RA|
-||NIST CSF 2.0|PR.PS|
 ||NIST SP 800-82:v3|SI-2|
 ||NIST SP 800-82:v3|RA-5|
 ||NIST SP 800-82:v3|CM-6|
+||NIST CSF 2.0|ID.RA-01|
+||NIST CSP 2.0|ID.IM|
+||NIST CSF 2.0|PR.PS|
+||NIST CSF 2.0|DE.CM-09|
+||MITRE ATT&CK|M0916|
+||MITRE ATT&CK|M0934|
+||MITRE ATT&CK|M0942|
+||MITRE ATT&CK|M0945|
+||MITRE ATT&CK|M0948|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.5|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.6|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.10|
 |3. Inadequate Supplier/Supply Chain Management|IEC 62443-2-1:2019|ORG 1.6|
 ||IEC 62443-3-2:2020|ZCR 5.X|
-||NIST CSF 2.0|GV.OC-02|
-||NIST CSF 2.0|GV.OC-04|
-||NIST CSF 2.0|GV.SC|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|5.X|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.1|
-||MITRE ATT&CK|M0817|
 ||NIST SP 800-82:v3|SR-2|
 ||NIST SP 800-82:v3|SR-3|
 ||NIST SP 800-82:v3|SR-5|
 ||NIST SP 800-82:v3|SR-6|
+||NIST CSF 2.0|GV.OC-03|
+||NIST CSF 2.0|GV.OC-04|
+||NIST CSF 2.0|GV.OC-05|
+||NIST CSF 2.0|GV.SC|
+||NIST CSF 2.0|ID.RA-10|
+||MITRE ATT&CK|M0817|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|5.X|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.1|
 |4. Insufficient Access Control|IEC 62443|FR 1|
 ||IEC 62443|FR 2|
 ||IEC 62443-2-1:2019|SPE 2|
 ||IEC 62443-3-3:2020|SR 1.X|
 ||IEC 62443-3-3:2020|SR 2.X|
+||NIST SP 800-82:v3|AC-2|
+||NIST SP 800-82:v3|AC-3|
+||NIST SP 800-82:v3|AC-6|
+||NIST SP 800-82:v3|AC-5|
+||NIST CSF 2.0|ID.IM-01|
+||NIST CSF 2.0|ID.IM-03|
 ||NIST CSF 2.0|PR.AA|
+||NIST CSF 2.0|PR.PS-05|
 ||NIST CSF 2.0|PR.IR-01|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.7|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|11.X|
 ||MITRE ATT&CK|M0800|
 ||MITRE ATT&CK|M0801|
 ||MITRE ATT&CK|M0804|
@@ -73,93 +87,107 @@ The following table maps the OWASP OT top 10 items to relevant standard and legi
 ||MITRE ATT&CK|M0918|
 ||MITRE ATT&CK|M0922|
 ||MITRE ATT&CK|M0926|
-||NIST SP 800-82:v3|AC-2|
-||NIST SP 800-82:v3|AC-3|
-||NIST SP 800-82:v3|AC-6|
-||NIST SP 800-82:v3|AC-5|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.7|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|11.X|
 |5. Missing Incident Detection/Reaction Capabilities|IEC 62443|FR 6|
 ||IEC 62443-2-1:2019|ORG 2.2|
 ||IEC 62443-2-1:2019|SPE 7|
 ||IEC 62443-3-2:2020|ZCR 5.1|
 ||IEC 62443-3-2:2020|SR 6.X|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|3.X|
-||MITRE ATT&CK|M0919|
-||MITRE ATT&CK|M0931|
-||NIST CSF 2.0|DE.CM|
-||NIST CSF 2.0|DE.AE|
-||NIST CSF 2.0|RS.MA|
-||NIST CSF 2.0|RS.AN|
 ||NIST SP 800-82:v3|IR-4|
 ||NIST SP 800-82:v3|SI-4|
 ||NIST SP 800-82:v3|AU-6|
 ||NIST SP 800-82:v3|IR-6|
+||NIST CSF 2.0|GV.SC-08|
+||NIST CSF 2.0|ID.IM-04|
+||NIST CSF 2.0|DE.CM|
+||NIST CSF 2.0|DE.AE|
+||NIST CSF 2.0|RS.X|
+||MITRE ATT&CK|M0919|
+||MITRE ATT&CK|M0931|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|3.X|
 |6. Broken Zones and Conduits Design|ISO27001 Annex|A.8.22|
 ||IEC 62443|FR 5|
 ||IEC 62443-2-1:2019|SPE 3|
 ||IEC 62443-3-2:2020|ZCR 3.X|
 ||IEC 62443-3-2:2020|SR 5.X|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.7|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.8|
-||MITRE ATT&CK|M0930|
-||MITRE ATT&CK|M0935|
-||MITRE ATT&CK|M0937|
 ||NIST SP 800-82:v3|SC-7|
 ||NIST SP 800-82:v3|AC-4|
 ||NIST SP 800-82:v3|SC-2|
+||NIST CSF 2.0|ID.IM|
+||NIST CSF 2.0|PR.IR-01|
+||MITRE ATT&CK|M0930|
+||MITRE ATT&CK|M0935|
+||MITRE ATT&CK|M0937|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.7|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.8|
 |7. Missing Awareness|IEC 62443-2-1:2019|ORG 1.4|
 ||IEC 62443-3-3:2020|SR 7.6|
 ||IEC 62443-3-3:2020|SR 7.7|
-||NIST CSF 2.0|PR.AT|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|8.1|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|8.2|
-||MITRE ATT&CK|M0917|
 ||NIST SP 800-82:v3|AT-2|
 ||NIST SP 800-82:v3|AT-3|
+||NIST CSF 2.0|PR.AT|
+||MITRE ATT&CK|M0917|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|8.1|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|8.2|
 |8. Components/Protocols with Insufficient Security Capabilities|IEC 62443-2-4:2024|SP.03.03|
 ||IEC 62443-3-2:2020|ZCR 5.X|
 ||IEC 62443-4-2:2020|CCSC 2|
+||NIST SP 800-82:v3|PM-1|
+||NIST SP 800-82:v3|CA-2|
+||NIST SP 800-82:v3|CA-7|
+||NIST CSF 2.0|ID.RA-01|
+||NIST CSF 2.0|ID.IM|
 ||NIST CSF 2.0|PR.AA-02|
+||NIST CSF 2.0|PR.PS-01|
+||NIST CSF 2.0|PR.PS-02|
+||NIST CSF 2.0|PR.PS-03|
+||NIST CSF 2.0|PR.PS-06|
 ||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.3|
 ||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.5|
 ||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.10|
 ||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|12.2|
-||NIST SP 800-82:v3|PM-1|
-||NIST SP 800-82:v3|CA-2|
-||NIST SP 800-82:v3|CA-7|
 |9. Loss of Availability|IEC 62443|FR 7|
 ||IEC 62443-2-1:2019|DATA 1.3|
 ||IEC 62443-2-1:2019|DATA 1.4|
 ||IEC 62443-2-1:2019|SPE 8|
 ||IEC 62443-3-3:2020|SR 7.X|
+||NIST SP 800-82:v3|CP-2|
+||NIST SP 800-82:v3|CP-7|
+||NIST SP 800-82:v3|CP-9|
+||NIST SP 800-82:v3|CP-10|
+||NIST CSF 2.0|GV.OC-04|
+||NIST CSF 2.0|GV.OC-05|
+||NIST CSF 2.0|GV.SC-07|
+||NIST CSF 2.0|GV.SC-08|
+||NIST CSF 2.0|PR.AA-02|
 ||NIST CSF 2.0|PR.IR-02|
 ||NIST CSF 2.0|PR.IR-03|
 ||NIST CSF 2.0|PR.IR-04|
-||NIST CSF 2.0|RC|
-||NIST CSF 2.0|PR.AA-02|
 ||NIST CSF 2.0|DE.CM|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|4.X|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.4|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|13.1|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|13.2|
+||NIST CSF 2.0|RC.RP-01|
+||NIST CSF 2.0|RC.RP-02|
+||NIST CSF 2.0|RC.RP-04|
 ||MITRE ATT&CK|M0803|
 ||MITRE ATT&CK|M0811|
 ||MITRE ATT&CK|M0812|
 ||MITRE ATT&CK|M0815|
 ||MITRE ATT&CK|M0953|
-||NIST SP 800-82:v3|CP-2|
-||NIST SP 800-82:v3|CP-7|
-||NIST SP 800-82:v3|CP-9|
-||NIST SP 800-82:v3|CP-10|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|4.X|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.4|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|13.1|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|13.2|
 |10. Missing Hardening|IEC 62443-2-1:2019|ORG 1.5|
 ||IEC 62443-2-1:2024|COMP 1.1|
 ||IEC 62443-2-4:2024|SP.02.03|
-||IEC 62443-3-3:2024||
+||IEC 62443-3-3:2024|X|
 ||IEC 62443-4-1:2018|SG-3|
-||IEC 62443-4-2||
+||IEC 62443-4-2|X|
+||NIST SP 800-82:v3|CM-6|
+||NIST SP 800-82:v3|CM-7|
+||NIST SP 800-82:v3|SI-3|
+||NIST SP 800-82:v3|SC-28|
 ||NIST CSF 2.0|PR.PS|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.3|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.9|
-||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|12.3|
 ||MITRE ATT&CK|M0806|
 ||MITRE ATT&CK|M0818|
 ||MITRE ATT&CK|M0921|
@@ -175,7 +203,6 @@ The following table maps the OWASP OT top 10 items to relevant standard and legi
 ||MITRE ATT&CK|M0950|
 ||MITRE ATT&CK|M0951|
 ||MITRE ATT&CK|M0954|
-||NIST SP 800-82:v3|CM-6|
-||NIST SP 800-82:v3|CM-7|
-||NIST SP 800-82:v3|SI-3|
-||NIST SP 800-82:v3|SC-28|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.3|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|6.9|
+||EU NIS2 Directive Commission implementing Regulation C(2024) 7151 - ANNEX|12.3|


### PR DESCRIPTION
Content of mapping table was reviewed, adapted and extended w.r.t. NIST CSF 2.0 requirements;

List of mapped standards and requirements is now sorted according to a bottom up approach (detailed/specific standards and their requirements are mentioned first, followed by a more generic/abstract one)