### PR TITLE
Update related-standards.md

### DIFF
--- a/docs/v/2025/background-ot/related-standards.md
+++ b/docs/v/2025/background-ot/related-standards.md
@@ -91,4 +91,4 @@ The Radio Equipment Directive (RED) regulates the placing of radio equipment on 
 
 ## Mapping Table
 
-A [Mapping table](https://ot.owasp.org/v/2025/appendix/mappingTable/) linking the OWASP OT Top 10 items to some of the mentioned relevant standard and regulation requirements is provided.
+A [Mapping table](../appendix/mappingTable.md) linking the OWASP OT Top 10 items to some of the mentioned relevant standard and regulation requirements is provided.

--- a/docs/v/2025/background-ot/related-standards.md
+++ b/docs/v/2025/background-ot/related-standards.md
@@ -91,4 +91,4 @@ The Radio Equipment Directive (RED) regulates the placing of radio equipment on 
 
 ## Mapping Table
 
-A [Mapping table](https://ot.owasp.org/appendix/mappingTable/) linking the OWASP OT Top 10 items to some of the mentioned relevant standard and regulation requirements is provided.
+A [Mapping table](https://ot.owasp.org/v/2025/appendix/mappingTable/) linking the OWASP OT Top 10 items to some of the mentioned relevant standard and regulation requirements is provided.


### PR DESCRIPTION
fixed reference to standard mapping table, since it is now located in folder /v/2025/ .